### PR TITLE
Fix inconsistency when batching

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/database/SQLManager.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/database/SQLManager.java
@@ -328,7 +328,7 @@ public class SQLManager implements AbstractDB {
             }
             int count = -1;
             if (!this.plotTasks.isEmpty()) {
-                count = 0;
+                count = Math.max(count, 0);
                 if (this.connection.getAutoCommit()) {
                     this.connection.setAutoCommit(false);
                 }
@@ -381,7 +381,7 @@ public class SQLManager implements AbstractDB {
                 }
             }
             if (!this.playerTasks.isEmpty()) {
-                count = 0;
+                count = Math.max(count, 0);
                 if (this.connection.getAutoCommit()) {
                     this.connection.setAutoCommit(false);
                 }
@@ -426,7 +426,7 @@ public class SQLManager implements AbstractDB {
                 }
             }
             if (!this.clusterTasks.isEmpty()) {
-                count = 0;
+                count = Math.max(count, 0);
                 if (this.connection.getAutoCommit()) {
                     this.connection.setAutoCommit(false);
                 }


### PR DESCRIPTION
Fixing issue #25 by using `count = Math.max(count, 0)` instead of `count = 0` for every map-block. The count variable doesn't get reset this way and no tasks are dropped. 
We have a fork of this running on `griefergames.net`, cb1. It was also tested on our testing infrastructure. Feel free to write me on Discord, If there are any questions. 