### PR TITLE
Fix invalid UUID conversion

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/util/UUIDHandlerImplementation.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/util/UUIDHandlerImplementation.java
@@ -162,7 +162,13 @@ public abstract class UUIDHandlerImplementation {
         try {
             UUID offline = this.uuidMap.put(name, uuid);
             if (offline != null) {
-                if (!offline.equals(uuid)) {
+                if (offline.equals(uuid)) {
+                    StringWrapper oName = this.uuidMap.inverse().get(offline);
+                    if (!oName.equals(name)) {
+                        this.uuidMap.remove(oName);
+                        this.uuidMap.put(name, uuid);
+                    }
+                } else if (Settings.UUID.OFFLINE) {
                     Set<Plot> plots = PS.get().getPlots(offline);
                     if (!plots.isEmpty()) {
                         for (Plot plot : plots) {
@@ -171,12 +177,6 @@ public abstract class UUIDHandlerImplementation {
                         replace(offline, uuid, name.value);
                     }
                     return true;
-                } else {
-                    StringWrapper oName = this.uuidMap.inverse().get(offline);
-                    if (!oName.equals(name)) {
-                        this.uuidMap.remove (name);
-                        this.uuidMap.put(name, uuid);
-                    }
                 }
                 return false;
             }

--- a/Core/src/main/java/com/intellectualcrafters/plot/util/UUIDHandlerImplementation.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/util/UUIDHandlerImplementation.java
@@ -116,10 +116,14 @@ public abstract class UUIDHandlerImplementation {
                 @Override
                 public void run() {
                     UUID offline = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name.value).getBytes(Charsets.UTF_8));
-                    if (!UUIDHandlerImplementation.this.unknown.contains(offline) && !name.value.equals(name.value.toLowerCase())) {
-                        offline = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name.value.toLowerCase()).getBytes(Charsets.UTF_8));
-                        if (!UUIDHandlerImplementation.this.unknown.contains(offline)) {
+                    if (!UUIDHandlerImplementation.this.unknown.contains(offline)) {
+                        if (name.value.equals(name.value.toLowerCase())) {
                             offline = null;
+                        } else {
+                            offline = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name.value.toLowerCase()).getBytes(Charsets.UTF_8));
+                            if (!UUIDHandlerImplementation.this.unknown.contains(offline)) {
+                                offline = null;
+                            }
                         }
                     }
                     if (offline != null && !offline.equals(uuid)) {

--- a/Core/src/main/java/com/intellectualcrafters/plot/util/UUIDHandlerImplementation.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/util/UUIDHandlerImplementation.java
@@ -168,6 +168,7 @@ public abstract class UUIDHandlerImplementation {
                         this.uuidMap.remove(oName);
                         this.uuidMap.put(name, uuid);
                     }
+                    return false;
                 } else if (Settings.UUID.OFFLINE) {
                     Set<Plot> plots = PS.get().getPlots(offline);
                     if (!plots.isEmpty()) {
@@ -176,9 +177,8 @@ public abstract class UUIDHandlerImplementation {
                         }
                         replace(offline, uuid, name.value);
                     }
-                    return true;
                 }
-                return false;
+                return true;
             }
         } catch (Exception ignored) {
             BiMap<UUID, StringWrapper> inverse = this.uuidMap.inverse();


### PR DESCRIPTION
Let's say we have 2 players.
Player1(name=a,uuid=a12..)
Player2(name=c,uuid=ce2..)

They do the following things:
  1. Player1 claims a Plot (e.g. 0;-1) -> PlotSquared saves (0;-1,a12..).
  2. Player1 leaves and renames to b -> Player1(name=b,uuid=a12..)
  3. Player2 can now rename to a -> Player2(name=a,uuid=ce2..)
  4. When Player2 joins, he get's all plots from Player1 -> the database now contains (0;-1,ce2..)
  5. When Player1 joins, he has no plots

Normally this behavior should only happen when offline mode is enabled.